### PR TITLE
URL 리더: X(트위터) 단일 트윗 링크 지원

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -109,7 +109,7 @@
   }
 
   function viaLabel(v) {
-    return { direct: "직접 수집", proxy: "프록시 우회", paste: "붙여넣기" }[v] || "";
+    return { direct: "직접 수집", proxy: "프록시 우회", tweet: "트윗", paste: "붙여넣기" }[v] || "";
   }
   function fillList(id, items) {
     const ul = $(id); ul.innerHTML = "";

--- a/src/lib/fetchArticle.js
+++ b/src/lib/fetchArticle.js
@@ -57,21 +57,65 @@ async function tryProxy(url) {
  * URL에서 { title, text, via }를 반환. 모든 전략 실패 시 에러를 던진다.
  * @param {string} url
  */
+// ── X(트위터) 전용 수집 ──────────────────────────────────────────
+// 트윗은 로그인·JS·봇차단으로 일반 fetch가 막힌다. 텍스트만 주는 공개 API로 우회.
+const TWEET_RE = /(?:twitter\.com|x\.com)\/([^/?#]+)\/status\/(\d+)/i;
+const isTweet = (url) => TWEET_RE.test(url);
+
+// 1순위: fxtwitter 공개 API (깔끔한 JSON, 인용 트윗까지)
+async function tryTweetFx(url) {
+  const id = url.match(TWEET_RE)[2];
+  const res = await fetch(`https://api.fxtwitter.com/status/${id}`, { headers: BROWSER_HEADERS });
+  if (!res.ok) throw new Error(`tweet-fx ${res.status}`);
+  const data = await res.json();
+  const t = data && data.tweet;
+  if (!t || !t.text) throw new Error("tweet-fx empty");
+  let text = t.text;
+  if (t.quote && t.quote.text) {
+    text += `\n\n[인용한 트윗 - @${(t.quote.author && t.quote.author.screen_name) || ""}]\n${t.quote.text}`;
+  }
+  const handle = (t.author && t.author.screen_name) || url.match(TWEET_RE)[1];
+  const name = (t.author && t.author.name) || handle;
+  return { title: `${name} (@${handle}) 트윗`, text, via: "tweet" };
+}
+
+// 2순위: 공식 oEmbed (첫 트윗 텍스트)
+async function tryTweetOembed(url) {
+  const api = `https://publish.twitter.com/oembed?url=${encodeURIComponent(url)}&omit_script=true&dnt=true`;
+  const res = await fetch(api, { headers: BROWSER_HEADERS });
+  if (!res.ok) throw new Error(`tweet-oembed ${res.status}`);
+  const data = await res.json();
+  if (!data || !data.html) throw new Error("tweet-oembed empty");
+  const text = parse(data.html).text.replace(/\s+/g, " ").trim();
+  if (!text) throw new Error("tweet-oembed no text");
+  return { title: data.author_name ? `${data.author_name} 트윗` : "트윗", text, via: "tweet" };
+}
+
+/**
+ * URL에서 { title, text, via }를 반환. 모든 전략 실패 시 에러를 던진다.
+ * @param {string} url
+ */
 export async function fetchArticle(url) {
   if (!/^https?:\/\//i.test(url)) {
     throw new Error("올바른 http(s) 링크를 입력해주세요.");
   }
 
+  // 트윗이면 트윗 전용 전략을 먼저 시도한다.
+  const strategies = isTweet(url)
+    ? [tryTweetFx, tryTweetOembed, tryProxy]
+    : [tryDirect, tryProxy];
+
   const errors = [];
-  for (const strategy of [tryDirect, tryProxy]) {
+  for (const strategy of strategies) {
     try {
       return await strategy(url);
     } catch (e) {
       errors.push(e.message);
     }
   }
-  throw new Error(
-    `이 링크의 본문을 가져오지 못했습니다 (${errors.join(", ")}). ` +
-      `봇 차단이 강한 사이트일 수 있어요. 원문 본문을 복사해서 "본문 붙여넣기"로 넣어주세요.`
-  );
+
+  const hint = isTweet(url)
+    ? `긴 스레드는 첫 트윗만 받아오거나 막힐 수 있어요. 트윗 본문을 복사해 "본문 붙여넣기"로 넣어주세요.`
+    : `봇 차단이 강한 사이트일 수 있어요. 원문 본문을 복사해서 "본문 붙여넣기"로 넣어주세요.`;
+  throw new Error(`이 링크의 본문을 가져오지 못했습니다 (${errors.join(", ")}). ${hint}`);
 }


### PR DESCRIPTION
## 개요

URL 리더에 **X(트위터) 단일 트윗 링크 지원**을 추가합니다.

## 배경
트위터/X는 로그인·JS·강한 봇차단으로 일반 fetch가 막혀, 지금까지 본문 붙여넣기로만 처리 가능했습니다. 단일 트윗은 공개 API로 텍스트를 받아올 수 있어 링크만으로 처리되게 합니다.

## 변경 (`src/lib/fetchArticle.js`, `public/app.js`)
- `x.com`/`twitter.com`의 `/status/<id>` 링크 감지
- 수집 전략: **fxtwitter API → 공식 oEmbed → 프록시** 순으로 시도
- 인용 트윗 텍스트도 함께 수집
- 실패 시 안내 분기(긴 스레드는 첫 트윗만/막힐 수 있음 → 붙여넣기 권장)
- `via` 라벨에 "트윗" 추가

## 한계
- 단일 트윗은 OK, **긴 스레드는 첫 트윗만** 받아올 수 있음 → 전체는 붙여넣기 권장
- 외부 API(fxtwitter)는 커뮤니티 서비스라 가끔 막힐 수 있어 oEmbed/붙여넣기로 폴백

## 참고
- 이 PR은 `master`(URL 리더)를 대상으로 합니다. 회의록(녹음) 앱이 올라간 `claude/unclear-request-plepdz` 브랜치와는 무관합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011A3wrQvwPPrsE4YLR2ctom)_