### PR TITLE
리더 안정화: Claude 호출 스트리밍 + 재시도 + IPv4 우선 (Premature close 수정)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "main": "src/server.js",
   "scripts": {
-    "start": "node src/server.js",
-    "dev": "node --watch src/server.js"
+    "start": "node --dns-result-order=ipv4first src/server.js",
+    "dev": "node --dns-result-order=ipv4first --watch src/server.js"
   },
   "engines": {
     "node": ">=20"

--- a/src/lib/distill.js
+++ b/src/lib/distill.js
@@ -108,7 +108,7 @@ export async function distillArticle(text, { url = "", sourceTitle = "" } = {}) 
     .filter(Boolean)
     .join("\n");
 
-  const message = await client().messages.create({
+  const params = {
     model: MODEL,
     max_tokens: 16000,
     system: SYSTEM,
@@ -120,9 +120,23 @@ export async function distillArticle(text, { url = "", sourceTitle = "" } = {}) 
         content: `${header}\n\n아래 영어 본문을 위 원칙에 따라 한글로 번역·구조화·증류해줘.\n\n---\n${text}`,
       },
     ],
-  });
+  };
 
-  const block = message.content.find((b) => b.type === "text");
-  if (!block) throw new Error("Claude 응답에서 결과를 찾지 못했습니다.");
-  return JSON.parse(block.text);
+  // Render↔Anthropic 간헐적 연결 끊김("Premature close") 대비:
+  // 스트리밍으로 받아 연결을 유지하고, 실패하면 최대 3회 재시도한다.
+  let lastErr;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const stream = client().messages.stream(params);
+      const message = await stream.finalMessage();
+      const block = message.content.find((b) => b.type === "text");
+      if (!block) throw new Error("Claude 응답에서 결과를 찾지 못했습니다.");
+      return JSON.parse(block.text);
+    } catch (err) {
+      lastErr = err;
+      if (attempt < 3) await new Promise((r) => setTimeout(r, 3000 * attempt)); // 3s, 6s
+    }
+  }
+  throw lastErr;
 }
+


### PR DESCRIPTION
## 문제

리더 사용 중 `Invalid response body while trying to fetch https://api.anthropic.com/v1/messages: Premature close` 발생. 트윗 수집은 성공했고, **Claude API 응답을 다 받기 전에 연결이 끊긴** 것(Render↔Anthropic 간헐적 연결 불안정).

## 해결 (`src/lib/distill.js`, `package.json`)
- **스트리밍 전환**: `messages.create` → `messages.stream` + `finalMessage()` — 긴 응답에서 연결을 유지해 `Premature close` 방지 (Anthropic 공식 권장)
- **자동 재시도**: 실패 시 최대 3회(3s·6s 백오프)
- **IPv4 우선**: `node --dns-result-order=ipv4first` (Render↔Anthropic 연결 안정화)
- 구조화 출력(json_schema)·adaptive thinking 그대로 유지

## 검증
- 구문 검사 통과, ipv4first start로 서버 부팅·헬스·UI 확인
- 실제 Claude 호출은 배포 후 라이브에서 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011A3wrQvwPPrsE4YLR2ctom)_